### PR TITLE
RISC-V: loom: expand stub size of continuation_enter_intrinsic

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3030,7 +3030,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       CodeBuffer buffer(buf);
 
       if (method->is_continuation_enter_intrinsic()) {
-        buffer.initialize_stubs_size(128);
+        buffer.initialize_stubs_size(NOT_RISCV64(128) RISCV64_ONLY(256));  // TODO: the real value?
       }
 
       struct { double data[20]; } locs_buf;

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -3030,7 +3030,7 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
       CodeBuffer buffer(buf);
 
       if (method->is_continuation_enter_intrinsic()) {
-        buffer.initialize_stubs_size(NOT_RISCV64(128) RISCV64_ONLY(256));  // TODO: the real value?
+        buffer.initialize_stubs_size(NOT_RISCV64(128) RISCV64_ONLY(192));
       }
 
       struct { double data[20]; } locs_buf;


### PR DESCRIPTION
a fix for:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/cpu/riscv/compiledIC_riscv.cpp:155), pid=110, tid=133
#  assert(stub != __null) failed: no stub found for static call
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x70a24e]  CompiledDirectStaticCall::verify()+0x1dc
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
```