### PR TITLE
RISC-V: loom: fix two frame::sender_sp_offset

### DIFF
--- a/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
@@ -61,7 +61,7 @@ inline frame FreezeBase::sender(const frame& f) {
   }
 
   intptr_t** link_addr = link_address<FKind>(f);
-  intptr_t* sender_sp = (intptr_t*)(link_addr + frame::sender_sp_offset); //  f.unextended_sp() + (fsize/wordSize); //
+  intptr_t* sender_sp = (intptr_t*)(link_addr + 2); //  f.unextended_sp() + (fsize/wordSize); //
   address sender_pc = (address) *(sender_sp - 1);
   assert(sender_sp != f.sp(), "must have changed");
 

--- a/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
@@ -37,7 +37,7 @@ static inline intptr_t** link_address(const frame& f) {
   assert(FKind::is_instance(f), "");
   return FKind::interpreted
             ? (intptr_t**)(f.fp() + frame::link_offset)
-            : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - frame::sender_sp_offset);
+            : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - 2);
 }
 
 inline int ContinuationHelper::frame_align_words(int size) {


### PR DESCRIPTION
This fixes:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000004002c0daac, pid=1012, tid=1030
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x12a5aac]  JVM_handle_linux_signal+0x10c
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Mon Sep  5 08:25:36 2022 UTC elapsed time: 2.223545 seconds (0d 0h 0m 2s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b910):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_vm, id=1030, stack(0x00000040c3441000,0x00000040c3641000)]

Stack: [0x00000040c3441000,0x00000040c3641000],  sp=0x00000040c363de60,  free space=2035k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x12a5aac]  JVM_handle_linux_signal+0x10c
C  0x00000040c363df60
V  [libjvm.so+0x753250]  FreezeBase::recurse_freeze(frame&, frame&, int, bool, bool)+0x2c2
V  [libjvm.so+0x754468]  FreezeBase::freeze_slow()+0x1c4
V  [libjvm.so+0x76082a]  int freeze_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0x432
V  [libjvm.so+0x760ac8]  int freeze<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0xda
J 2  jdk.internal.vm.Continuation.doYield()I java.base@20-internal (0 bytes) @ 0x00000040136bb5d8 [0x00000040136bb580+0x0000000000000058]

[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49)]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 2  jdk.internal.vm.Continuation.doYield()I java.base@20-internal (0 bytes) @ 0x00000040136bb594 [0x00000040136bb580+0x0000000000000014]
j  jdk.internal.vm.Continuation.yield0(Ljdk/internal/vm/ContinuationScope;Ljdk/internal/vm/Continuation;)Z+18 java.base@20-internal
j  jdk.internal.vm.Continuation.yield(Ljdk/internal/vm/ContinuationScope;)Z+69 java.base@20-internal
j  java.lang.VirtualThread.yieldContinuation()Z+20 java.base@20-internal
j  java.lang.VirtualThread.park()V+43 java.base@20-internal
j  java.lang.System$2.parkVirtualThread()V+17 java.base@20-internal
j  jdk.internal.misc.VirtualThreads.park()V+3 java.base@20-internal
j  java.util.concurrent.locks.LockSupport.park()V+9 java.base@20-internal
j  VThread.lambda$testStartVirtualThread$0()V+8
j  VThread$$Lambda$2+0x0000000800000a08.run()V+0
j  java.lang.VirtualThread.run(Ljava/lang/Runnable;)V+66 java.base@20-internal
j  java.lang.VirtualThread$VThreadContinuation.lambda$new$0(Ljava/lang/VirtualThread;Ljava/lang/Runnable;)V+2 java.base@20-internal
j  java.lang.VirtualThread$VThreadContinuation$$Lambda$8+0x000000080001ea58.run()V+8 java.base@20-internal
j  jdk.internal.vm.Continuation.enter0()V+4 java.base@20-internal
j  jdk.internal.vm.Continuation.enter(Ljdk/internal/vm/Continuation;Z)V+1 java.base@20-internal
J 1  jdk.internal.vm.Continuation.enterSpecial(Ljdk/internal/vm/Continuation;ZZ)V java.base@20-internal (0 bytes) @ 0x00000040137f6838 [0x00000040137f6040+0x00000000000007f8]
j  jdk.internal.vm.Continuation.run()V+122 java.base@20-internal
j  java.lang.VirtualThread.runContinuation()V+81 java.base@20-internal
j  java.lang.VirtualThread$$Lambda$9+0x000000080001ec80.run()V+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask.doExec()I+10 java.base@20-internal
j  java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+19 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I+203 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+35 java.base@20-internal
j  java.util.concurrent.ForkJoinWorkerThread.run()V+31 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136964e0
```