### PR TITLE
RISC-V: loom: Fix one fsize calculation: same as AArch64

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1045,7 +1045,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_interpreted_frame(frame& f, fr
   // The frame's top never includes the stack arguments to the callee
   intptr_t* const stack_frame_top = ContinuationHelper::InterpretedFrame::frame_top(f, callee_argsize, callee_interpreted);
   const int locals = f.interpreter_frame_method()->max_locals();
-  const int fsize = f.fp() + frame::metadata_words + locals - stack_frame_top;
+  const int fsize = f.fp() - 2 /* keep the fp as the AArch64 one to get the same result */ + frame::metadata_words + locals - stack_frame_top;
 
   intptr_t* const stack_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(f);
   assert(stack_frame_bottom - stack_frame_top >= fsize, ""); // == on x86

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1045,7 +1045,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_interpreted_frame(frame& f, fr
   // The frame's top never includes the stack arguments to the callee
   intptr_t* const stack_frame_top = ContinuationHelper::InterpretedFrame::frame_top(f, callee_argsize, callee_interpreted);
   const int locals = f.interpreter_frame_method()->max_locals();
-  const int fsize = f.fp() RISCV64_ONLY(-2) + frame::metadata_words + locals - stack_frame_top;
+  const int fsize = f.fp() NOT_RISCV64(+ frame::metadata_words) + locals - stack_frame_top;
 
   intptr_t* const stack_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(f);
   assert(stack_frame_bottom - stack_frame_top >= fsize, ""); // == on x86

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1045,7 +1045,7 @@ NOINLINE freeze_result FreezeBase::recurse_freeze_interpreted_frame(frame& f, fr
   // The frame's top never includes the stack arguments to the callee
   intptr_t* const stack_frame_top = ContinuationHelper::InterpretedFrame::frame_top(f, callee_argsize, callee_interpreted);
   const int locals = f.interpreter_frame_method()->max_locals();
-  const int fsize = f.fp() - 2 /* keep the fp as the AArch64 one to get the same result */ + frame::metadata_words + locals - stack_frame_top;
+  const int fsize = f.fp() RISCV64_ONLY(-2) + frame::metadata_words + locals - stack_frame_top;
 
   intptr_t* const stack_frame_bottom = ContinuationHelper::InterpretedFrame::frame_bottom(f);
   assert(stack_frame_bottom - stack_frame_top >= fsize, ""); // == on x86


### PR DESCRIPTION
Fix:

Now the `fsize` has kept aligned with the AArch64 ones.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/runtime/continuationFreezeThaw.cpp:1067), pid=140, tid=158
#  Error: assert(stack_frame_bottom - stack_frame_top >= fsize) failed
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x7538f6]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x9f2
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Tue Sep  6 04:25:04 2022 UTC elapsed time: 2.260213 seconds (0d 0h 0m 2s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b410):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_vm, id=158, stack(0x00000040c3441000,0x00000040c3641000)]

Stack: [0x00000040c3441000,0x00000040c3641000],  sp=0x00000040c363e150,  free space=2036k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x7538f6]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x9f2  (continuationFreezeThaw.cpp:1067)
V  [libjvm.so+0x7540b6]  FreezeBase::freeze_slow()+0x206
V  [libjvm.so+0x76078c]  int freeze_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0x432
V  [libjvm.so+0x760a2a]  int freeze<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0xda
J 2  jdk.internal.vm.Continuation.doYield()I java.base@20-internal (0 bytes) @ 0x00000040136bb820 [0x00000040136bb580+0x00000000000002a0]

[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49)]

```

Now the crash has come to: 
```
#  Internal Error (/jdk/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp:42), pid=212, tid=230
#  Error: Unimplemented()
```