### PR TITLE
RISC-V: loom: fix *addr_at() -> at() in frame for frame::interpreter_…

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -311,7 +311,7 @@ BasicObjectLock* frame::interpreter_frame_monitor_begin() const {
 }
 
 BasicObjectLock* frame::interpreter_frame_monitor_end() const {
-  BasicObjectLock* result = (BasicObjectLock*) *addr_at(interpreter_frame_monitor_block_top_offset);
+  BasicObjectLock* result = (BasicObjectLock*) at(interpreter_frame_monitor_block_top_offset);
   // make sure the pointer points inside the frame
   assert(sp() <= (intptr_t*) result, "monitor end should be above the stack pointer");
   assert((intptr_t*) result < fp(),  "monitor end should be strictly below the frame pointer");


### PR DESCRIPTION
Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/cpu/riscv/frame_riscv.cpp:317), pid=398, tid=416
#  assert((intptr_t*) result < fp()) failed: monitor end should be strictly below the frame pointer
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x8aa384]  frame::interpreter_frame_monitor_end() const+0x176
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Tue Sep  6 08:46:27 2022 UTC elapsed time: 2.394905 seconds (0d 0h 0m 2s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b410):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_vm, id=416, stack(0x00000040c3442000,0x00000040c3642000)]

Stack: [0x00000040c3442000,0x00000040c3642000],  sp=0x00000040c363d640,  free space=2029k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x8aa384]  frame::interpreter_frame_monitor_end() const+0x176  (frame_riscv.cpp:317)
V  [libjvm.so+0x89fd22]  frame::interpreter_frame_expression_stack_size() const+0x16
V  [libjvm.so+0x8a201a]  frame::interpreter_frame_print_on(outputStream*) const+0x1c4
V  [libjvm.so+0x75330c]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x656
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753500]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x84a
V  [libjvm.so+0x753ec6]  FreezeBase::freeze_slow()+0x206
V  [libjvm.so+0x7602f8]  int freeze_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0x432
V  [libjvm.so+0x760596]  int freeze<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0xda
J 2  jdk.internal.vm.Continuation.doYield()I java.base@20-internal (0 bytes) @ 0x00000040136bc820 [0x00000040136bc580+0x00000000000002a0]

[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49)]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 1  jdk.internal.vm.Continuation.enterSpecial(Ljdk/internal/vm/Continuation;ZZ)V java.base@20-internal (0 bytes) @ 0x00000040137f70e0 [0x00000040137f6440+0x0000000000000ca0]
j  jdk.internal.vm.Continuation.run()V+122 java.base@20-internal
j  java.lang.VirtualThread.runContinuation()V+81 java.base@20-internal
j  java.lang.VirtualThread$$Lambda$9+0x000000080001ec80.run()V+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask.doExec()I+10 java.base@20-internal
j  java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+19 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I+203 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+35 java.base@20-internal
j  java.util.concurrent.ForkJoinWorkerThread.run()V+31 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136974e0
Registers:
pc      =0x0000004002212384
x1(ra)  =0x0000004002207d22
x2(sp)  =0x00000040c363d640
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36418f0
x5(t0)  =0x00000040c363c768
x6(t1)  =0x0000004001b6f56c
x7(t2)  =0x000000000000000a
x8(s0)  =0x00000040c363d680
x9(s1)  =0x00000040c363d7c0
x10(a0) =0x0000004002f8a438
x11(a1) =0x000000000000013d
x12(a2) =0x0000004002f8a628
x13(a3) =0x0000004002f8a5f0
x14(a4) =0x0000000000000058
x15(a5) =0x0000004013656000
x16(a6) =0x0000000000000000
x17(a7) =0x0000000000000009
x18(s2) =0xfffffffffffffff4
x19(s3) =0xffffffffffffffff
x20(s4) =0x0000004003180890
x21(s5) =0xffffffffffffffff
x22(s6) =0x0000004002f89688
x23(s7) =0x0000004002f89670
x24(s8) =0xfffffffffffffffe
x25(s9) =0x0000004002ee9210
x26(s10)=0x0000004002ee91e0
x27(s11)=0x0000004003180890
x28(t3) =0x0000004001846244
x29(t4) =0x0000000000000002
x30(t5) =0x00000040c363c790
x31(t6) =0x000000000000002a
```