### PR TITLE
RISC-V: loom: port StackChunkFrameStream::to_frame

### DIFF
--- a/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
@@ -39,8 +39,11 @@ inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
 
 template <ChunkFrames frame_kind>
 inline frame StackChunkFrameStream<frame_kind>::to_frame() const {
-  Unimplemented();
-  return frame();
+  if (is_done()) {
+    return frame(_sp, _sp, nullptr, nullptr, nullptr, nullptr, true);
+  } else {
+    return frame(sp(), unextended_sp(), fp(), pc(), cb(), _oopmap, true);
+  }
 }
 
 template <ChunkFrames frame_kind>


### PR DESCRIPTION
The same as the aarch64 counterpart.