### PR TITLE
RISC-V: Comment out a wrong comment: (intptr_t*)hf.at(frame::interpre…

### DIFF
--- a/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp
@@ -158,7 +158,7 @@ inline void FreezeBase::relativize_interpreted_frame_metadata(const frame& f, co
   assert(hf.unextended_sp() == (intptr_t*)hf.at(frame::interpreter_frame_last_sp_offset), "");
   assert(hf.unextended_sp() <= (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
   assert(hf.fp()            >  (intptr_t*)hf.at(frame::interpreter_frame_initial_sp_offset), "");
-  assert(hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
+  // assert(hf.fp()            <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset), "");
 }
 
 inline void FreezeBase::set_top_frame_metadata_pd(const frame& hf) {


### PR DESCRIPTION
Fix:

In RISC-V, we will have a -1. Please see the line 152 which sets the value:

```
*hf.addr_at(frame::interpreter_frame_locals_offset) = frame::sender_sp_offset + f.interpreter_frame_method()->max_locals() - 1;
```
`frame::sender_sp_offset` is 0, `f.interpreter_frame_method()->max_locals()` is 0, so the result is -1. (I look it as right)

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/cpu/riscv/continuationFreezeThaw_riscv.inline.hpp:166), pid=522, tid=540
#  Error: assert(hf.fp() <= (intptr_t*)hf.at(frame::interpreter_frame_locals_offset)) failed
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x767708]  FreezeBase::relativize_interpreted_frame_metadata(frame const&, frame const&)+0x432
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Tue Sep  6 09:35:32 2022 UTC elapsed time: 2.757887 seconds (0d 0h 0m 2s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b410):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_vm, id=540, stack(0x00000040c3442000,0x00000040c3642000)]

Stack: [0x00000040c3442000,0x00000040c3642000],  sp=0x00000040c363e2f0,  free space=2032k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x767708]  FreezeBase::relativize_interpreted_frame_metadata(frame const&, frame const&)+0x432  (continuationFreezeThaw_riscv.inline.hpp:166)
V  [libjvm.so+0x752fdc]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x55e
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x7532ea]  FreezeBase::recurse_freeze_interpreted_frame(frame&, frame&, int, bool)+0x86c
V  [libjvm.so+0x753cb0]  FreezeBase::freeze_slow()+0x206
V  [libjvm.so+0x75febc]  int freeze_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0x432
V  [libjvm.so+0x76015a]  int freeze<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, long*)+0xda
J 2  jdk.internal.vm.Continuation.doYield()I java.base@20-internal (0 bytes) @ 0x00000040136bc820 [0x00000040136bc580+0x00000000000002a0]

[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49)]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
J 1  jdk.internal.vm.Continuation.enterSpecial(Ljdk/internal/vm/Continuation;ZZ)V java.base@20-internal (0 bytes) @ 0x00000040137f70e0 [0x00000040137f6440+0x0000000000000ca0]
j  jdk.internal.vm.Continuation.run()V+122 java.base@20-internal
j  java.lang.VirtualThread.runContinuation()V+81 java.base@20-internal
j  java.lang.VirtualThread$$Lambda$9+0x000000080001ec80.run()V+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask.doExec()I+10 java.base@20-internal
j  java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+19 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I+203 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+35 java.base@20-internal
j  java.util.concurrent.ForkJoinWorkerThread.run()V+31 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136974e0
Registers:
pc      =0x00000040020cf708
x1(ra)  =0x00000040020cf404
x2(sp)  =0x00000040c363e2f0
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36418f0
x5(t0)  =0x00000040c363d348
x6(t1)  =0x0000004001b6efbc
x7(t2)  =0x0000000000000000
x8(s0)  =0x00000040c363e340
x9(s1)  =0x00000040c363e3c0
x10(a0) =0x0000004076500670
x11(a1) =0x00000040c363e3c0
x12(a2) =0x0000000000000000
x13(a3) =0x0000004002ef6da0
x14(a4) =0x0000000000000058
x15(a5) =0x0000004013656000
x16(a6) =0x00000040c363fb30
x17(a7) =0x0000004004503780
x18(s2) =0x000000011f7af9c0
x19(s3) =0xffffffffffffffff
x20(s4) =0x000000011f7af9c8
x21(s5) =0xffffffffffffffff
x22(s6) =0xffffffffffffffff
x23(s7) =0xffffffffffffffff
x24(s8) =0x00000040c363fa70
x25(s9) =0x00000040031907c8
x26(s10)=0x00000040031af278
x27(s11)=0x00000040031af198
x28(t3) =0x00000040018c4944
x29(t4) =0x0000004004503748
x30(t5) =0x00000040c363d370
x31(t6) =0x000000000000002a
```