### PR TITLE
RISC-V: continuation_enter_cleanup() isn't compatible with leave(): the settled fp will be destroyed by RISC-V's leave()

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -4165,7 +4165,7 @@ void fill_continuation_entry(MacroAssembler* masm) {
 }
 
 // on entry, sp points to the ContinuationEntry
-// on exit, rfp points to the spilled rfp + 2 * wordSize in the entry frame
+// on exit, fp points to the spilled fp + 2 * wordSize in the entry frame
 void continuation_enter_cleanup(MacroAssembler* masm) {
 #ifndef PRODUCT
   Label OK;


### PR DESCRIPTION
This fixes:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGILL (0x4) at pc=0x0000004000000000, pid=748, tid=766
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# C  [java+0x0]
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode -Xlog:continuations=debug VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Tue Sep  6 12:03:19 2022 UTC elapsed time: 2.584396 seconds (0d 0h 0m 2s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b420):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=766, stack(0x00000040c3442000,0x00000040c3642000)]

Stack: [0x00000040c3442000,0x00000040c3642000],  sp=0x00000040c363fe00,  free space=2039k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  [java+0x0]
[error occurred during error reporting (printing native stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/utilities/elfFile.cpp:742)]


siginfo: si_signo: 4 (SIGILL), si_code: 1 (ILL_ILLOPC), si_addr: 0x0000000000000000

Registers:
pc      =0x0000004000000000
x1(ra)  =0x0000004000000000
x2(sp)  =0x00000040c363fe00
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36418f0
x5(t0)  =0x0000000000000000
x6(t1)  =0x0000004001b6f2bc
x7(t2)  =0x0000000000000000
x8(s0)  =0x0000000000000000
x9(s1)  =0x00000000000000b8
x10(a0) =0x0000000000000000
x11(a1) =0x000000400453c2b0
x12(a2) =0x00000000000000d8
x13(a3) =0x00000000000000d8
x14(a4) =0x000000400453bac0
x15(a5) =0x0000000000000004
x16(a6) =0x00000040c3641258
x17(a7) =0x0000000000000040
x18(s2) =0x0000000000000108
x19(s3) =0x00000040c363f700
x20(s4) =0x00000040c363f740
x21(s5) =0x000000400322f578
x22(s6) =0x000000407608d932
x23(s7) =0x000000400453b420
x24(s8) =0x00000040c363f7b8
x25(s9) =0x00000040c36404c0
x26(s10)=0x00000040765a65e0
x27(s11)=0x0000000000000000
x28(t3) =0x00000040018112ce
x29(t4) =0x00000040c363f278
x30(t5) =0x00000040c363eb70
x31(t6) =0x000000407608d2d8


Register to memory mapping:

pc      =0x0000004000000000: <offset 0x0000000000000000> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/bin/java at 0x0000004000000000
x1(ra)  =0x0000004000000000: <offset 0x0000000000000000> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/bin/java at 0x0000004000000000
x2(sp)  =0x00000040c363fe00 is pointing into the stack for thread: 0x000000400453b420
x3(gp)  =0x0000004000002800 points into unknown readable memory: 0x0000000000000000 | 00 00 00 00 00 00 00 00
x4(tp)  =0x00000040c36418f0 is pointing into the stack for thread: 0x000000400453b420
x5(t0)  =0x0 is NULL
x6(t1)  =0x0000004001b6f2bc: <offset 0x00000000002072bc> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x7(t2)  =0x0 is NULL
x8(s0)  =0x0 is NULL
x9(s1)  =0x00000000000000b8 is an unknown value
x10(a0) =0x0 is NULL
x11(a1) =0x000000400453c2b0 points into unknown readable memory: 0x0000000000000003 | 03 00 00 00 00 00 00 00
x12(a2) =0x00000000000000d8 is an unknown value
x13(a3) =0x00000000000000d8 is an unknown value
x14(a4) =0x000000400453bac0 points into unknown readable memory: 0xf1f1f1f100000002 | 02 00 00 00 f1 f1 f1 f1
x15(a5) =0x0000000000000004 is an unknown value
x16(a6) =0x00000040c3641258 is pointing into the stack for thread: 0x000000400453b420
x17(a7) =0x0000000000000040 is an unknown value
x18(s2) =0x0000000000000108 is an unknown value
x19(s3) =0x00000040c363f700 is pointing into the stack for thread: 0x000000400453b420
x20(s4) =0x00000040c363f740 is pointing into the stack for thread: 0x000000400453b420
x21(s5) =0x000000400322f578: <offset 0x00000000018c7578> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x22(s6) =0x000000407608d932 is pointing into metadata
x23(s7) =0x000000400453b420 is a thread
x24(s8) =0x00000040c363f7b8 is pointing into the stack for thread: 0x000000400453b420
x25(s9) =0x00000040c36404c0 is pointing into the stack for thread: 0x000000400453b420
x26(s10)=0x00000040765a65e0 is pointing into metadata
x27(s11)=0x0 is NULL
x28(t3) =0x00000040018112ce: __tls_get_addr+0x0000000000000000 in /lib/ld-linux-riscv64-lp64d.so.1 at 0x0000004001804000
x29(t4) =0x00000040c363f278 is pointing into the stack for thread: 0x000000400453b420
x30(t5) =0x00000040c363eb70 is pointing into the stack for thread: 0x000000400453b420
x31(t6) ={method} {0x000000407608d2d8} 'doYield' '()I' in 'jdk/internal/vm/Continuation'
```

I observed wrong fp and lr of the frozen target coroutine are loaded at the last step of yielding. Then I remembered the `leave()` is not compatible between AArch64 and RISC-V64. (Don't know the fix is ugly or not, but it works: I have come to the thaw part after this one)