### PR TITLE
RISC-V: loom: Fix missing ported loom logic for frame::sender_for_interpreter_frame

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -422,6 +422,14 @@ frame frame::sender_for_interpreter_frame(RegisterMap* map) const {
   }
 #endif // COMPILER2
 
+  if (Continuation::is_return_barrier_entry(sender_pc())) {
+    if (map->walk_cont()) { // about to walk into an h-stack
+      return Continuation::top_frame(*this, map);
+    } else {
+      return Continuation::continuation_bottom_sender(map->thread(), *this, sender_sp);
+    }
+  }
+
   return frame(sender_sp, unextended_sp, link(), sender_pc());
 }
 


### PR DESCRIPTION
Fix a missing port in `frame::sender_for_interpreter_frame`:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49), pid=1219, tid=1237
#  assert(cb != __null) failed: must be
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x3ecfb8]  frame::sender_for_compiled_frame(RegisterMap*) const+0x356
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode -Xlog:continuations=debug VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Wed Sep  7 05:39:53 2022 UTC elapsed time: 3.590091 seconds (0d 0h 0m 3s)

---------------  T H R E A D  ---------------

Current thread (0x0000004004533420):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=1237, stack(0x00000040c3441000,0x00000040c3641000)]

Stack: [0x00000040c3441000,0x00000040c3641000],  sp=0x00000040c363da60,  free space=2034k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x3ecfb8]  frame::sender_for_compiled_frame(RegisterMap*) const+0x356  (codeCache.inline.hpp:49)
V  [libjvm.so+0x744ca4]  ContinuationEntry::assert_entry_frame_laid_out(JavaThread*)+0x696
V  [libjvm.so+0x75991c]  long* thaw_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, Continuation::thaw_kind)+0x39e
V  [libjvm.so+0x759fdc]  long* thaw<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, int)+0x50
v  ~BufferBlob::StubRoutines (3) 0x000000401369bb38
j  jdk.internal.vm.Continuation.run()V+152 java.base@20-internal
j  java.lang.VirtualThread.runContinuation()V+81 java.base@20-internal
j  java.lang.VirtualThread$$Lambda$9+0x000000080001ec80.run()V+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask.doExec()I+10 java.base@20-internal
j  java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+19 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I+203 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+35 java.base@20-internal
j  java.util.concurrent.ForkJoinWorkerThread.run()V+31 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136964e0
V  [libjvm.so+0xb3b29e]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x4f4
V  [libjvm.so+0xb3b7d0]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x398
V  [libjvm.so+0xb3bb22]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, JavaThread*)+0x54
V  [libjvm.so+0xca0fd4]  thread_entry(JavaThread*, JavaThread*)+0x108
V  [libjvm.so+0xb6d5a0]  JavaThread::thread_main_inner()+0x24a
V  [libjvm.so+0x13bbf80]  Thread::call_run()+0xd4
V  [libjvm.so+0x10303a2]  thread_native_entry(Thread*)+0xf2
C  [libpthread.so.0+0x7600]  start_thread+0xae
C  [libc.so.6+0xa73c6]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  jdk.internal.vm.Continuation.yield0(Ljdk/internal/vm/ContinuationScope;Ljdk/internal/vm/Continuation;)Z+18 java.base@20-internal
j  jdk.internal.vm.Continuation.yield(Ljdk/internal/vm/ContinuationScope;)Z+69 java.base@20-internal
v  ~BufferBlob::StubRoutines (3) 0x000000401369bdb4

[error occurred during error reporting (printing Java stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/code/codeCache.inline.hpp:49)]

Registers:
pc      =0x0000004001d54fb8
x1(ra)  =0x0000004001d54d9c
x2(sp)  =0x00000040c363da60
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36408f0
x5(t0)  =0x00000040c363d078
x6(t1)  =0x0000004001b6fbec
x7(t2)  =0x000000000000000a
x8(s0)  =0x00000040c363dae0
x9(s1)  =0x00000040c363db40
x10(a0) =0x0000000000000000
x11(a1) =0x0000000000000096
x12(a2) =0x0000004002efa0d8
x13(a3) =0x0000004002ee5e88
x14(a4) =0x0000004000015530
x15(a5) =0x0000004013655000
x16(a6) =0x0000000000000007
x17(a7) =0x00000000000000ff
x18(s2) =0x000000011f0cd060
x19(s3) =0x00000040c363edc0
x20(s4) =0x0000000000000058
x21(s5) =0x000000011f0abcc0
x22(s6) =0x000000400317f890
x23(s7) =0x000000400321fe68
x24(s8) =0x00000040c363db40
x25(s9) =0x00000040c363db40
x26(s10)=0x000000400317f890
x27(s11)=0x000000401369ba10
x28(t3) =0x00000040018c45ec
x29(t4) =0x0000000000000001
x30(t5) =0x00000040c363d0a0
x31(t6) =0x000000000000002a
```