### PR TITLE
RISC-V: loom: Fix newly added frame::frame(sp)'s fp calculation

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -148,7 +148,7 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   setup(pc);
 }
 
-inline frame::frame(intptr_t* ptr_sp) : frame(ptr_sp, ptr_sp, *(intptr_t**)(ptr_sp - frame::sender_sp_offset), *(address*)(ptr_sp - 1)) {}
+inline frame::frame(intptr_t* ptr_sp) : frame(ptr_sp, ptr_sp, *(intptr_t**)(ptr_sp - 2), *(address*)(ptr_sp - 1)) {}
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   intptr_t a = intptr_t(ptr_sp);


### PR DESCRIPTION
Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000400220865e, pid=1734, tid=1752
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x8a065e]  frame::interpreter_frame_method() const+0xb2
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode -XX:+LoomVerifyAfterThaw -Xlog:continuations=debug VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Wed Sep  7 08:29:32 2022 UTC elapsed time: 3.330782 seconds (0d 0h 0m 3s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b380):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=1752, stack(0x00000040c3443000,0x00000040c3643000)]

Stack: [0x00000040c3443000,0x00000040c3643000],  sp=0x00000040c3640390,  free space=2036k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x8a065e]  frame::interpreter_frame_method() const+0xb2
V  [libjvm.so+0x8a3270]  frame::interpreter_frame_print_on(outputStream*) const+0x158
V  [libjvm.so+0x759db0]  long* thaw_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, Continuation::thaw_kind)+0x3c6
V  [libjvm.so+0x75a418]  long* thaw<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, int)+0x50
v  ~BufferBlob::StubRoutines (3) 0x000000401369db38
j  jdk.internal.vm.Continuation.run()V+152 java.base@20-internal
j  java.lang.VirtualThread.runContinuation()V+81 java.base@20-internal
j  java.lang.VirtualThread$$Lambda$9+0x000000080001ec80.run()V+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec()Z+4 java.base@20-internal
j  java.util.concurrent.ForkJoinTask.doExec()I+10 java.base@20-internal
j  java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(Ljava/util/concurrent/ForkJoinTask;Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+19 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.scan(Ljava/util/concurrent/ForkJoinPool$WorkQueue;II)I+203 java.base@20-internal
j  java.util.concurrent.ForkJoinPool.runWorker(Ljava/util/concurrent/ForkJoinPool$WorkQueue;)V+35 java.base@20-internal
j  java.util.concurrent.ForkJoinWorkerThread.run()V+31 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136984e0
V  [libjvm.so+0xb3c184]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x4f4
V  [libjvm.so+0xb3c6b6]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x398
V  [libjvm.so+0xb3ca08]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, JavaThread*)+0x54
V  [libjvm.so+0xca1a68]  thread_entry(JavaThread*, JavaThread*)+0x108
V  [libjvm.so+0xb6e338]  JavaThread::thread_main_inner()+0x24a
V  [libjvm.so+0x13bd618]  Thread::call_run()+0xd4
V  [libjvm.so+0x1031514]  thread_native_entry(Thread*)+0xf2
C  [libpthread.so.0+0x7600]  start_thread+0xae
C  [libc.so.6+0xa73c6]


siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000000000

Registers:
pc      =0x000000400220865e
x1(ra)  =0x000000400220b270
x2(sp)  =0x00000040c3640390
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36428f0
x5(t0)  =0x00000040c363f488
x6(t1)  =0x0000004001b6f56c
x7(t2)  =0x0000000000000000
x8(s0)  =0x00000040c36403b0
x9(s1)  =0x0000000000000000
x10(a0) =0x00000040c3640490
x11(a1) =0x0000004004000b70
x12(a2) =0xffffffffffffffff
x13(a3) =0x00000040136a53c4
x14(a4) =0x0000004001e8bb18
x15(a5) =0x00000040c3640cc0
x16(a6) =0x0000000000000000
x17(a7) =0x0000000000000009
x18(s2) =0x00000040c3640490
x19(s3) =0x0000000000000000
x20(s4) =0x0000000000000000
x21(s5) =0xffffffffffffffff
x22(s6) =0x0000004002f89fb8
x23(s7) =0x0000004002f89fa0
x24(s8) =0x0000000000000001
x25(s9) =0x0000004002ee97f8
x26(s10)=0x0000004002ee97c8
x27(s11)=0x0000004003181890
x28(t3) =0x0000004001846244
x29(t4) =0x00000040030bcb80
x30(t5) =0x00000040c363f4b0
x31(t6) =0x000000000000002a

```