### PR TITLE
RISC-V: loom: Adjust leave() once again (need refactoring)

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3884,11 +3884,13 @@ class StubGenerator: public StubCodeGenerator {
       __ mv(x10, x9); // restore return value contaning the exception oop
       __ verify_oop(x10);
 
+      __ addi(fp, fp, 2 * wordSize);  // 2 extra words to match up with leave()
       __ leave();
       __ mv(x13, ra);
       __ jr(x11); // the exception handler
     } else {
       // We're "returning" into the topmost thawed frame; see Thaw::push_return_frame
+      __ addi(fp, fp, 2 * wordSize);  // 2 extra words to match up with leave()
       __ leave();
       __ ret();
     }


### PR DESCRIPTION
Same as #9 

(Code needs some refactoring)

Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x000000407608d3a8, pid=1786, tid=1804
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# C  0x000000407608d3a8
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode -XX:+LoomVerifyAfterThaw -Xlog:continuations=debug VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Wed Sep  7 08:38:46 2022 UTC elapsed time: 5.324894 seconds (0d 0h 0m 5s)

---------------  T H R E A D  ---------------

Current thread (0x0000004004533230):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=1804, stack(0x00000040c3443000,0x00000040c3643000)]

Stack: [0x00000040c3443000,0x00000040c3643000],  sp=0x00000040c3640cb0,  free space=2039k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
C  0x000000407608d3a8


siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x00000000000000f8

Registers:
pc      =0x000000407608d3a8
x1(ra)  =0x000000407608d3a8
x2(sp)  =0x00000040c3640cb0
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36428f0
x5(t0)  =0x00000040c36406e8
x6(t1)  =0x00000040c3640cc0
x7(t2)  =0x0000000000000000
x8(s0)  =0x00000040c363fa70
x9(s1)  =0x00000000000000b8
x10(a0) =0x0000000000000000
x11(a1) =0x00000040045340c0
x12(a2) =0xffffffffffffffff
x13(a3) =0x00000040c4000d00
x14(a4) =0x0000000000000001
x15(a5) =0x0000000000000000
x16(a6) =0x00000040c3642258
x17(a7) =0x0000000000000040
x18(s2) =0x0000000000000108
x19(s3) =0x00000040c3640e10
x20(s4) =0x00000040c3640e38
x21(s5) =0x0000004003230578
x22(s6) =0x000000407608ce38
x23(s7) =0x0000004004533230
x24(s8) =0x00000040c3640ed8
x25(s9) =0x00000040c36414c0
x26(s10)=0x00000040765a65e0
x27(s11)=0x0000000000000000
x28(t3) =0x00000040018112ce
x29(t4) =0x00000040c3640178
x30(t5) =0x00000040c363fa70
x31(t6) =0x000000407608d3a8


Register to memory mapping:

pc      ={method} {0x000000407608d3a8} 'enterSpecial' '(Ljdk/internal/vm/Continuation;ZZ)V' in 'jdk/internal/vm/Continuation'
x1(ra)  ={method} {0x000000407608d3a8} 'enterSpecial' '(Ljdk/internal/vm/Continuation;ZZ)V' in 'jdk/internal/vm/Continuation'
x2(sp)  =0x00000040c3640cb0 is pointing into the stack for thread: 0x0000004004533230
x3(gp)  =0x0000004000002800 points into unknown readable memory: 0x0000000000000000 | 00 00 00 00 00 00 00 00
x4(tp)  =0x00000040c36428f0 is pointing into the stack for thread: 0x0000004004533230
x5(t0)  =0x00000040c36406e8 is pointing into the stack for thread: 0x0000004004533230
x6(t1)  =0x00000040c3640cc0 is pointing into the stack for thread: 0x0000004004533230
x7(t2)  =0x0 is NULL
x8(s0)  =0x00000040c363fa70 is pointing into the stack for thread: 0x0000004004533230
x9(s1)  =0x00000000000000b8 is an unknown value
x10(a0) =0x0 is NULL
x11(a1) =0x00000040045340c0 points into unknown readable memory: 0x0000000000000003 | 03 00 00 00 00 00 00 00
x12(a2) =0xffffffffffffffff is an unknown value
x13(a3) =0x00000040c4000d00 points into unknown readable memory: 0x00000000ffffffff | ff ff ff ff 00 00 00 00
x14(a4) =0x0000000000000001 is an unknown value
x15(a5) =0x0 is NULL
x16(a6) =0x00000040c3642258 is pointing into the stack for thread: 0x0000004004533230
x17(a7) =0x0000000000000040 is an unknown value
x18(s2) =0x0000000000000108 is an unknown value
x19(s3) =0x00000040c3640e10 is pointing into the stack for thread: 0x0000004004533230
x20(s4) =0x00000040c3640e38 is pointing into the stack for thread: 0x0000004004533230
x21(s5) =0x0000004003230578: <offset 0x00000000018c8578> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x22(s6) =0x000000407608ce38 is pointing into metadata
x23(s7) =0x0000004004533230 is a thread
x24(s8) =0x00000040c3640ed8 is pointing into the stack for thread: 0x0000004004533230
x25(s9) =0x00000040c36414c0 is pointing into the stack for thread: 0x0000004004533230
x26(s10)=0x00000040765a65e0 is pointing into metadata
x27(s11)=0x0 is NULL
x28(t3) =0x00000040018112ce: __tls_get_addr+0x0000000000000000 in /lib/ld-linux-riscv64-lp64d.so.1 at 0x0000004001804000
x29(t4) =0x00000040c3640178 is pointing into the stack for thread: 0x0000004004533230
x30(t5) =0x00000040c363fa70 is pointing into the stack for thread: 0x0000004004533230
x31(t6) ={method} {0x000000407608d3a8} 'enterSpecial' '(Ljdk/internal/vm/Continuation;ZZ)V' in 'jdk/internal/vm/Continuation'

```