### PR TITLE
RISC-V: loom: Remove interpreter_frame_locals_offset >= fp check

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -475,7 +475,7 @@ bool frame::is_interpreted_frame_valid(JavaThread* thread) const {
 
   // validate locals
   address locals = (address) *interpreter_frame_locals_addr();
-  if (locals > thread->stack_base() || locals < (address) fp()) {
+  if (locals > thread->stack_base() /*|| locals < (address) fp() */) {
     return false;
   }
 


### PR DESCRIPTION
Same as #8 .

Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/runtime/continuationFreezeThaw.cpp:2097), pid=1806, tid=1824
#  assert(f.is_interpreted_frame_valid(_cont.thread())) failed: invalid thawed frame
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, interpreted mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x757370]  ThawBase::recurse_thaw_interpreted_frame(frame const&, frame&, int)+0x9e4
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -Xint -XX:-PrintStubCode -XX:+LoomVerifyAfterThaw -Xlog:continuations=debug VThread

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Wed Sep  7 08:46:20 2022 UTC elapsed time: 4.062457 seconds (0d 0h 0m 4s)

---------------  T H R E A D  ---------------

Current thread (0x000000400453b370):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=1824, stack(0x00000040c3443000,0x00000040c3643000)]

Stack: [0x00000040c3443000,0x00000040c3643000],  sp=0x00000040c3640290,  free space=2036k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x757370]  ThawBase::recurse_thaw_interpreted_frame(frame const&, frame&, int)+0x9e4  (continuationFreezeThaw.cpp:2097)
V  [libjvm.so+0x7580a0]  ThawBase::thaw_slow(stackChunkOop, bool)+0x27c
V  [libjvm.so+0x759cec]  long* thaw_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, Continuation::thaw_kind)+0x302
V  [libjvm.so+0x75a418]  long* thaw<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, int)+0x50
v  ~BufferBlob::StubRoutines (3) 0x000000401369de9c

Registers:
pc      =0x00000040020bf370
x1(ra)  =0x00000040020bef28
x2(sp)  =0x00000040c3640290
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040c36428f0
x5(t0)  =0x00000040c363f2b8
x6(t1)  =0x0000004002de0406
x7(t2)  =0x000000000000000a
x8(s0)  =0x00000040c36404b0
x9(s1)  =0x00000040c3640508
x10(a0) =0x0000004002f66b50
x11(a1) =0x0000000000000831
x12(a2) =0x0000004002f69db8
x13(a3) =0x0000004002f69da0
x14(a4) =0x0000000000000058
x15(a5) =0x0000004013657000
x16(a6) =0x00000040c3640d60
x17(a7) =0x00000040c3640d58
x18(s2) =0x00000040c3640548
x19(s3) =0x00000040c3640740
x20(s4) =0x00000040c3640dc0
x21(s5) =0x0000000000000001
x22(s6) =0x00000040c36402b0
x23(s7) =0x0000004003207f37
x24(s8) =0x00000040031b0278
x25(s9) =0x00000040031b0198
x26(s10)=0x00000040c3640330
x27(s11)=0x0000000000000000
x28(t3) =0x00000040018112ce
x29(t4) =0x0000000000000000
x30(t5) =0x00000040c363f2e0
x31(t6) =0x000000000000002a


Register to memory mapping:

pc      =0x00000040020bf370: <offset 0x0000000000757370> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x1(ra)  =0x00000040020bef28: <offset 0x0000000000756f28> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x2(sp)  =0x00000040c3640290 is pointing into the stack for thread: 0x000000400453b370
x3(gp)  =0x0000004000002800 points into unknown readable memory: 0x0000000000000000 | 00 00 00 00 00 00 00 00
x4(tp)  =0x00000040c36428f0 is pointing into the stack for thread: 0x000000400453b370
x5(t0)  =0x00000040c363f2b8 is pointing into the stack for thread: 0x000000400453b370
x6(t1)  =0x0000004002de0406: <offset 0x0000000001478406> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x7(t2)  =0x000000000000000a is an unknown value
x8(s0)  =0x00000040c36404b0 is pointing into the stack for thread: 0x000000400453b370
x9(s1)  =0x00000040c3640508 is pointing into the stack for thread: 0x000000400453b370
x10(a0) =0x0000004002f66b50: <offset 0x00000000015feb50> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x11(a1) =0x0000000000000831 is an unknown value
x12(a2) =0x0000004002f69db8: <offset 0x0000000001601db8> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x13(a3) =0x0000004002f69da0: <offset 0x0000000001601da0> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x14(a4) =0x0000000000000058 is an unknown value
x15(a5) =0x0000004013657000 points into unknown readable memory: 0x0000000000000058 | 58 00 00 00 00 00 00 00
x16(a6) =0x00000040c3640d60 is pointing into the stack for thread: 0x000000400453b370
x17(a7) =0x00000040c3640d58 is pointing into the stack for thread: 0x000000400453b370
x18(s2) =0x00000040c3640548 is pointing into the stack for thread: 0x000000400453b370
x19(s3) =0x00000040c3640740 is pointing into the stack for thread: 0x000000400453b370
x20(s4) =0x00000040c3640dc0 is pointing into the stack for thread: 0x000000400453b370
x21(s5) =0x0000000000000001 is an unknown value
x22(s6) =0x00000040c36402b0 is pointing into the stack for thread: 0x000000400453b370
x23(s7) =0x0000004003207f37: <offset 0x000000000189ff37> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x24(s8) =0x00000040031b0278: <offset 0x0000000001848278> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x25(s9) =0x00000040031b0198: <offset 0x0000000001848198> in /jdk/build/linux-riscv64-server-fastdebug/images/jdk/lib/server/libjvm.so at 0x0000004001968000
x26(s10)=0x00000040c3640330 is pointing into the stack for thread: 0x000000400453b370
x27(s11)=0x0 is NULL
x28(t3) =0x00000040018112ce: __tls_get_addr+0x0000000000000000 in /lib/ld-linux-riscv64-lp64d.so.1 at 0x0000004001804000
x29(t4) =0x0 is NULL
x30(t5) =0x00000040c363f2e0 is pointing into the stack for thread: 0x000000400453b370
x31(t6) =0x000000000000002a is an unknown value


```