### PR TITLE
RISC-V: loom: Fix a typo for frame::sender_for_compiled_frame

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -447,7 +447,7 @@ frame frame::sender_for_compiled_frame(RegisterMap* map) const {
     if (map->walk_cont()) { // about to walk into an h-stack
       return Continuation::top_frame(*this, map);
     } else {
-      Continuation::continuation_bottom_sender(map->thread(), *this, l_sender_sp);
+      return Continuation::continuation_bottom_sender(map->thread(), *this, l_sender_sp);
     }
   }
 


### PR DESCRIPTION
Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/runtime/continuation.cpp:301), pid=3505, tid=3600
#  assert(ce != nullptr) failed: callee.unextended_sp(): 0x00000043350bec90
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, mixed mode, emulated-client, tiered, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x742b6c]  Continuation::continuation_bottom_sender(JavaThread*, frame const&, long*)+0xc2
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dserver.port=19381 -DstartupBenchmark -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -XX:+UnlockExperimentalVMOptions -XX:+VMContinuations --enable-preview -XX:+UnlockExperimentalVMOptions -XX:-UseRVC -XX:+UseNewCode -XX:TieredStopAtLevel=1 -XX:-PrintStubCode -XX:+LoomVerifyAfterThaw -XX:CompileThreshold=2 VThread2

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Wed Sep  7 11:53:53 2022 UTC elapsed time: 6.253796 seconds (0d 0h 0m 6s)

---------------  T H R E A D  ---------------

Current thread (0x0000004004564930):  JavaThread "ForkJoinPool-1-worker-1" daemon [_thread_in_Java, id=3600, stack(0x0000004334ec1000,0x00000043350c1000)]

Stack: [0x0000004334ec1000,0x00000043350c1000],  sp=0x00000043350bd9f0,  free space=2034k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x742b6c]  Continuation::continuation_bottom_sender(JavaThread*, frame const&, long*)+0xc2  (continuation.cpp:301)
V  [libjvm.so+0x3ecdba]  frame::sender_for_compiled_frame(RegisterMap*) const+0x128
V  [libjvm.so+0x524bd2]  frame::sender(RegisterMap*) const+0x204
V  [libjvm.so+0x747f7c]  do_verify_after_thaw(JavaThread*, stackChunkOop, outputStream*)+0x476
V  [libjvm.so+0x759f96]  long* thaw_internal<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, Continuation::thaw_kind)+0x38a
V  [libjvm.so+0x75a6a4]  long* thaw<Config<(oop_kind)0, G1BarrierSet> >(JavaThread*, int)+0x50
v  ~BufferBlob::StubRoutines (3) 0x000000401369de9c

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  java.lang.System$2.parkVirtualThread()V+17 java.base@20-internal
J 1433 c1 java.util.concurrent.locks.LockSupport.park()V java.base@20-internal (24 bytes) @ 0x00000040142c2434 [0x00000040142c2340+0x00000000000000f4]
v  ~BufferBlob::StubRoutines (3) 0x000000401369ddbc

[error occurred during error reporting (printing Java stack), id 0xe0000000, Internal Error (/jdk/src/hotspot/share/runtime/continuation.cpp:301)]

Registers:
pc      =0x00000040020aab6c
x1(ra)  =0x0000004001d54dba
x2(sp)  =0x00000043350bd9f0
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000043350c08f0
x5(t0)  =0x00000043350bcb38
x6(t1)  =0x0000004001b6f59c
x7(t2)  =0x0000000000000010
x8(s0)  =0x00000043350bda80
x9(s1)  =0x0000000000000000
x10(a0) =0x00000043350bda80
x11(a1) =0x0000004004564930
x12(a2) =0x0000004013657000
x13(a3) =0xffffffffffffffff
x14(a4) =0x0000000000000058
x15(a5) =0x0000004003181890
x16(a6) =0x0000000000000000
x17(a7) =0x0000000000000009
x18(s2) =0x00000043350bda80
x19(s3) =0x00000043350bec90
x20(s4) =0x00000043350bdc78
x21(s5) =0x0000004004564930
x22(s6) =0x00000043350bec90
x23(s7) =0x00000040031b0278
x24(s8) =0x00000043350bdcb8
x25(s9) =0x0000000000000003
x26(s10)=0x0000004003221e68
x27(s11)=0x00000043350bd510
x28(t3) =0x0000004001846244
x29(t4) =0x000000401369ddbc
x30(t5) =0x00000043350bcb60
x31(t6) =0x000000000000002a
```