### PR TITLE
RISC-V: loom: port StackChunkFrameStream::is_in_frame

### DIFF
--- a/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
@@ -32,8 +32,11 @@
 #ifdef ASSERT
 template <ChunkFrames frame_kind>
 inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
-  Unimplemented();
-  return true;
+  assert(!is_done(), "");
+  intptr_t* p = (intptr_t*)p0;
+  int argsize = is_compiled() ? (_cb->as_compiled_method()->method()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord : 0;
+  int frame_size = _cb->frame_size() + argsize;
+  return p == sp() - 2 || ((p - unextended_sp()) >= 0 && (p - unextended_sp()) < frame_size);
 }
 #endif
 


### PR DESCRIPTION
Fix one `Unimplemented()`.

Now the compiled version of `VThread.java` has passed (c1, c2).