### PR TITLE
RISC-V: loom: fix a return address related calculation in return_barrier_exception handling

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3872,7 +3872,7 @@ class StubGenerator: public StubCodeGenerator {
     __ mv(fp, sp);
 
     if (return_barrier_exception) {
-      __ ld(c_rarg1, Address(fp, 1 * wordSize)); // return address
+      __ ld(c_rarg1, Address(fp, wordSize)); // return address
       __ verify_oop(x10);
       __ mv(x9, x10); // save return value contaning the exception oop in callee-saved R9
 


### PR DESCRIPTION
Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/runtime/sharedRuntime.cpp:464), pid=61409, tid=61611
#  assert(frame::verify_return_pc(return_address)) failed: must be a return address: 0x000000408205b5e0
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, mixed mode, tiered, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x11746aa]  SharedRuntime::raw_exception_handler_for_return_address(JavaThread*, unsigned char*)+0x174
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dtest.vm.opts=-ea -esa -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -Dtest.tool.vm.opts=-J-ea -J-esa -J-XX:-UseContainerSupport -J-Djdk.lang.Process.launchMechanism=vfork -Dtest.compiler.opts= -Dtest.java.opts= -Dtest.jdk=/jdk/build/linux-riscv64-server-fastdebug/images/jdk -Dcompile.jdk=/jdk/build/linux-riscv64-server-fastdebug/images/jdk -Dtest.timeout.factor=10.0 -Dtest.nativepath=/jdk/build/linux-riscv64-server-fastdebug/images/test/hotspot/jtreg/native -Dtest.root=/jdk/test/jdk -Dtest.name=java/lang/Thread/virtual/ThreadAPI.java#id0 -Dtest.file=/jdk/test/jdk/java/lang/Thread/virtual/ThreadAPI.java -Dtest.src=/jdk/test/jdk/java/lang/Thread/virtual -Dtest.src.path=/jdk/test/jdk/java/lang/Thread/virtual:/jdk/test/lib -Dtest.classes=/jdk/jtregReportDir/workdir/classes/1/java/lang/Thread/virtual/ThreadAPI_id0.d -Dtest.class.path=/jdk/jtregReportDir/workdir/classes/1/java/lang/Thread/virtual/ThreadAPI_id0.d:/jdk/jtregReportDir/workdir/classes/1/test/lib -Dtest.modules=java.base/java.lang:+open -Dtest.enable.preview=true --add-modules=java.base --add-exports=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED -ea -esa -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -Djava.library.path=/jdk/build/linux-riscv64-server-fastdebug/images/test/hotspot/jtreg/native --enable-preview com.sun.javatest.regtest.agent.MainWrapper /jdk/jtregReportDir/workdir/java/lang/Thread/virtual/ThreadAPI_id0.d/testng.1.jta java/lang/Thread/virtual/ThreadAPI.java#id0 false ThreadAPI

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Thu Sep  8 07:37:38 2022 UTC elapsed time: 17.713246 seconds (0d 0h 0m 17s)

---------------  T H R E A D  ---------------

Current thread (0x00000040fc3018a0):  JavaThread "ForkJoinPool-1-worker-63" daemon [_thread_in_Java, id=61611, stack(0x000000447e192000,0x000000447e392000)]

Stack: [0x000000447e192000,0x000000447e392000],  sp=0x000000447e38fc30,  free space=2039k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x11746aa]  SharedRuntime::raw_exception_handler_for_return_address(JavaThread*, unsigned char*)+0x174  (sharedRuntime.cpp:464)
V  [libjvm.so+0x1174b46]  SharedRuntime::exception_handler_for_return_address(JavaThread*, unsigned char*)+0x3c
v  ~BufferBlob::StubRoutines (3) 0x000000401aa6e076

Registers:
pc      =0x0000004002adc6aa
x1(ra)  =0x0000004002adc558
x2(sp)  =0x000000447e38fc30
x3(gp)  =0x0000004000002800
x4(tp)  =0x000000447e3918f0
x5(t0)  =0x0000004002adcb00
x6(t1)  =0x0000004001b6f2ec
x7(t2)  =0x00000001191b0030
x8(s0)  =0x000000447e38fcb0
x9(s1)  =0x000000408205b5e0
x10(a0) =0x0000004003070198
x11(a1) =0x00000000000001d0
x12(a2) =0x0000004003070240
x13(a3) =0x0000004003070218
x14(a4) =0x000000408205b5e0
x15(a5) =0x0000004013658000
x16(a6) =0x0000000000000058
x17(a7) =0x000000447e38fd90
x18(s2) =0x00000040fc3018a0
x19(s3) =0x0000004003182890
x20(s4) =0x000000408205b5e0
x21(s5) =0x0000004003231578
x22(s6) =0x000000408205b57e
x23(s7) =0x00000040fc3018a0
x24(s8) =0x000000447e38fdb8
x25(s9) =0x000000447e3904c0
x26(s10)=0x00000040828f11f8
x27(s11)=0x0000000000000000
x28(t3) =0x00000040018112ce
x29(t4) =0x000000402a7a045d
x30(t5) =0x000000401aa7985a
x31(t6) =0x000000408205b5e0
```