### PR TITLE
RISC-V: loom: Fix another frame::sender_sp_offset issue in stackChunkOopDesc::is_usable_in_chunk

### DIFF
--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -133,7 +133,7 @@ inline bool stackChunkOopDesc::is_in_chunk(void* p) const {
 bool stackChunkOopDesc::is_usable_in_chunk(void* p) const {
 #if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
   HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset;
-#elif defined(RISCV64)
+#elif defined(RISCV64) && !defined(ZERO)
   HeapWord* start = (HeapWord*)start_address() + sp() - 2;
 #else
   Unimplemented();

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -131,8 +131,10 @@ inline bool stackChunkOopDesc::is_in_chunk(void* p) const {
 }
 
 bool stackChunkOopDesc::is_usable_in_chunk(void* p) const {
-#if (defined(X86) || defined(AARCH64) || defined(RISCV64)) && !defined(ZERO)
+#if (defined(X86) || defined(AARCH64)) && !defined(ZERO)
   HeapWord* start = (HeapWord*)start_address() + sp() - frame::sender_sp_offset;
+#elif defined(RISCV64)
+  HeapWord* start = (HeapWord*)start_address() + sp() - 2;
 #else
   Unimplemented();
   HeapWord* start = NULL;


### PR DESCRIPTION
Fix:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  Internal Error (/jdk/src/hotspot/share/runtime/continuationWrapper.cpp:64), pid=58, tid=77
#  Error: assert(chunk->is_usable_in_chunk(p)) failed
#
# JRE version: OpenJDK Runtime Environment (20.0) (fastdebug build 20-internal-adhoc..jdk)
# Java VM: OpenJDK 64-Bit Server VM (fastdebug 20-internal-adhoc..jdk, compiled mode, compressed oops, compressed class ptrs, g1 gc, linux-riscv64)
# Problematic frame:
# V  [libjvm.so+0x77d176]  ContinuationWrapper::find_chunk_by_address(void*) const+0x54e
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#

---------------  S U M M A R Y ------------

Command Line: -Dtest.vm.opts=-ea -esa -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -Dtest.tool.vm.opts=-J-ea -J-esa -J-XX:-UseContainerSupport -J-Djdk.lang.Process.launchMechanism=vfork -Dtest.compiler.opts= -Dtest.java.opts= -Dtest.jdk=/jdk/riscv-loom-image/jdk -Dcompile.jdk=/jdk/riscv-loom-image/jdk -Dtest.timeout.factor=10.0 -Dtest.nativepath=/jdk/riscv-loom-image/test/jdk/jtreg/native -Dtest.root=/jdk/test/jdk -Dtest.name=jdk/internal/vm/Continuation/LiveFramesDriver.java -Dtest.file=/jdk/test/jdk/jdk/internal/vm/Continuation/LiveFramesDriver.java -Dtest.src=/jdk/test/jdk/jdk/internal/vm/Continuation -Dtest.src.path=/jdk/test/jdk/jdk/internal/vm/Continuation -Dtest.classes=/jdk/jtregReportDir/workdir/classes/0/jdk/internal/vm/Continuation/LiveFramesDriver.d -Dtest.class.path=/jdk/jtregReportDir/workdir/classes/0/jdk/internal/vm/Continuation/LiveFramesDriver.d -Dtest.modules=java.base/jdk.internal.vm -Dtest.patch.path= --patch-module=java.base=/jdk/jtregReportDir/workdir/classes/0/jdk/internal/vm/Continuation/LiveFramesDriver.d/patches/java.base --add-modules=java.base --add-exports=java.base/jdk.internal.vm=ALL-UNNAMED -ea -esa -XX:-UseContainerSupport -Djdk.lang.Process.launchMechanism=vfork -Djava.library.path=/jdk/riscv-loom-image/test/jdk/jtreg/native --enable-preview -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -Xcomp -XX:CompileOnly=jdk/internal/vm/Continuation,java/lang/LiveFrames com.sun.javatest.regtest.agent.MainWrapper /jdk/jtregReportDir/workdir/jdk/internal/vm/Continuation/LiveFramesDriver.d/main.3.jta

Host: e69e13043.et15sqa, RISCV64, 96 cores, 503G, Debian GNU/Linux bookworm/sid
Time: Fri Sep  9 02:23:07 2022 UTC elapsed time: 6.343507 seconds (0d 0h 0m 6s)

---------------  T H R E A D  ---------------

Current thread (0x00000040045da2a0):  JavaThread "MainThread" [_thread_in_vm, id=77, stack(0x00000040cb6b8000,0x00000040cb8b8000)]

Stack: [0x00000040cb6b8000,0x00000040cb8b8000],  sp=0x00000040cb8b44e0,  free space=2033k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V  [libjvm.so+0x77d176]  ContinuationWrapper::find_chunk_by_address(void*) const+0x54e  (continuationWrapper.cpp:64)
V  [libjvm.so+0x74087a]  Continuation::is_in_usable_stack(unsigned char*, RegisterMap const*)+0x36
V  [libjvm.so+0x12eccc6]  unsigned char* StackValue::stack_value_address<RegisterMap>(frame const*, RegisterMap const*, ScopeValue*)+0x232
V  [libjvm.so+0x12edba0]  StackValue* StackValue::create_stack_value<RegisterMap>(frame const*, RegisterMap const*, ScopeValue*)+0x14
V  [libjvm.so+0x146d9be]  compiledVFrame::create_stack_value(ScopeValue*) const+0x7e
V  [libjvm.so+0x146ea94]  compiledVFrame::locals() const+0x186
V  [libjvm.so+0x12f38e6]  LiveFrameStream::fill_live_stackframe(Handle, methodHandle const&, JavaThread*)+0xae
V  [libjvm.so+0x12f3c68]  LiveFrameStream::fill_frame(int, objArrayHandle, methodHandle const&, JavaThread*)+0xf6
V  [libjvm.so+0x12f4526]  StackWalk::fill_in_frames(long, BaseFrameStream&, int, int, objArrayHandle, int&, JavaThread*)+0x5aa
V  [libjvm.so+0x12f59e6]  StackWalk::fetchFirstBatch(BaseFrameStream&, Handle, long, int, int, int, objArrayHandle, JavaThread*)+0x522
V  [libjvm.so+0x12f6396]  StackWalk::walk(Handle, long, int, Handle, Handle, int, int, objArrayHandle, JavaThread*)+0x2a2
V  [libjvm.so+0xca390a]  JVM_CallStackWalk+0x18c
j  java.lang.StackStreamFactory$AbstractStackWalker.callStackWalk(JILjdk/internal/vm/ContinuationScope;Ljdk/internal/vm/Continuation;II[Ljava/lang/Object;)Ljava/lang/Object;+0 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.beginStackWalk()Ljava/lang/Object;+39 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.walkHelper()Ljava/lang/Object;+1 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker$$Lambda$40+0x00000008000a73d8.get()Ljava/lang/Object;+4 java.base@20-internal
J 59 c2 jdk.internal.vm.Continuation.wrapWalk(Ljdk/internal/vm/Continuation;Ljdk/internal/vm/ContinuationScope;Ljava/util/function/Supplier;)Ljava/lang/Object; java.base@20-internal (104 bytes) @ 0x00000040137c6000 [0x00000040137c5f40+0x00000000000000c0]
j  java.lang.StackStreamFactory$AbstractStackWalker.walk()Ljava/lang/Object;+28 java.base@20-internal
j  java.lang.StackWalker.forEach(Ljava/util/function/Consumer;)V+15 java.base@20-internal
j  java.lang.LiveFrames.testStackWalk(Ljava/lang/StackWalker;)V+14 java.base@20-internal
j  java.lang.LiveFrames.test1()V+54 java.base@20-internal
J 34 c2 java.lang.LiveFrames.main([Ljava/lang/String;)V java.base@20-internal (13 bytes) @ 0x00000040137b3d30 [0x00000040137b3cc0+0x0000000000000070]
j  LiveFramesDriver.main([Ljava/lang/String;)V+1
j  java.lang.invoke.LambdaForm$DMH+0x00000008000c0000.invokeStatic(Ljava/lang/Object;Ljava/lang/Object;)V+10 java.base@20-internal
j  java.lang.invoke.LambdaForm$MH+0x00000008000c3000.invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+33 java.base@20-internal
j  java.lang.invoke.Invokers$Holder.invokeExact_MT(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+20 java.base@20-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+55 java.base@20-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+23 java.base@20-internal
j  java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+102 java.base@20-internal
j  com.sun.javatest.regtest.agent.MainWrapper$MainThread.run()V+172
j  java.lang.Thread.run()V+13 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136994aa
V  [libjvm.so+0xb3c0a0]  JavaCalls::call_helper(JavaValue*, methodHandle const&, JavaCallArguments*, JavaThread*)+0x4f4
V  [libjvm.so+0xb3c5d2]  JavaCalls::call_virtual(JavaValue*, Klass*, Symbol*, Symbol*, JavaCallArguments*, JavaThread*)+0x398
V  [libjvm.so+0xb3c924]  JavaCalls::call_virtual(JavaValue*, Handle, Klass*, Symbol*, Symbol*, JavaThread*)+0x54
V  [libjvm.so+0xca1d68]  thread_entry(JavaThread*, JavaThread*)+0x108
V  [libjvm.so+0xb6e270]  JavaThread::thread_main_inner()+0x24a
V  [libjvm.so+0x13be616]  Thread::call_run()+0xd4
V  [libjvm.so+0x1031768]  thread_native_entry(Thread*)+0xf2
C  [libpthread.so.0+0x7600]  start_thread+0xae
C  [libc.so.6+0xa73c6]

Java frames: (J=compiled Java code, j=interpreted, Vv=VM code)
j  java.lang.StackStreamFactory$AbstractStackWalker.callStackWalk(JILjdk/internal/vm/ContinuationScope;Ljdk/internal/vm/Continuation;II[Ljava/lang/Object;)Ljava/lang/Object;+0 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.beginStackWalk()Ljava/lang/Object;+39 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker.walkHelper()Ljava/lang/Object;+1 java.base@20-internal
j  java.lang.StackStreamFactory$AbstractStackWalker$$Lambda$40+0x00000008000a73d8.get()Ljava/lang/Object;+4 java.base@20-internal
J 59 c2 jdk.internal.vm.Continuation.wrapWalk(Ljdk/internal/vm/Continuation;Ljdk/internal/vm/ContinuationScope;Ljava/util/function/Supplier;)Ljava/lang/Object; java.base@20-internal (104 bytes) @ 0x00000040137c6000 [0x00000040137c5f40+0x00000000000000c0]
j  java.lang.StackStreamFactory$AbstractStackWalker.walk()Ljava/lang/Object;+28 java.base@20-internal
j  java.lang.StackWalker.forEach(Ljava/util/function/Consumer;)V+15 java.base@20-internal
j  java.lang.LiveFrames.testStackWalk(Ljava/lang/StackWalker;)V+14 java.base@20-internal
j  java.lang.LiveFrames.test1()V+54 java.base@20-internal
J 34 c2 java.lang.LiveFrames.main([Ljava/lang/String;)V java.base@20-internal (13 bytes) @ 0x00000040137b3d30 [0x00000040137b3cc0+0x0000000000000070]
j  LiveFramesDriver.main([Ljava/lang/String;)V+1
j  java.lang.invoke.LambdaForm$DMH+0x00000008000c0000.invokeStatic(Ljava/lang/Object;Ljava/lang/Object;)V+10 java.base@20-internal
j  java.lang.invoke.LambdaForm$MH+0x00000008000c3000.invoke(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+33 java.base@20-internal
j  java.lang.invoke.Invokers$Holder.invokeExact_MT(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;+20 java.base@20-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+55 java.base@20-internal
j  jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+23 java.base@20-internal
j  java.lang.reflect.Method.invoke(Ljava/lang/Object;[Ljava/lang/Object;)Ljava/lang/Object;+102 java.base@20-internal
j  com.sun.javatest.regtest.agent.MainWrapper$MainThread.run()V+172
j  java.lang.Thread.run()V+13 java.base@20-internal
v  ~StubRoutines::call_stub 0x00000040136994aa
Registers:
pc      =0x00000040020e5176
x1(ra)  =0x00000040020a887a
x2(sp)  =0x00000040cb8b44e0
x3(gp)  =0x0000004000002800
x4(tp)  =0x00000040cb8b78f0
x5(t0)  =0x0000000000000004
x6(t1)  =0x0000004001b6f2ec
x7(t2)  =0x0000000000000010
x8(s0)  =0x00000040cb8b45b0
x9(s1)  =0x0000004003208f37
x10(a0) =0x00000040cb8b45b0
x11(a1) =0x00000040cb8b45c8
x12(a2) =0x00000000a0103690
x13(a3) =0x0000004002ef8898
x14(a4) =0x0000000000000058
x15(a5) =0x0000004013658000
x16(a6) =0x000000000000001c
x17(a7) =0x0000000000000212
x18(s2) =0x0000000000000024
x19(s3) =0x00000000a01036a0
x20(s4) =0x00000000a0103678
x21(s5) =0x00000000a0103690
x22(s6) =0x0000000000000120
x23(s7) =0x00000040cb8b4520
x24(s8) =0x00000000a0103690
x25(s9) =0x00000040cb8b4510
x26(s10)=0x00000040cb8b4508
x27(s11)=0x00000040cb8b44f8
x28(t3) =0x00000040018112ce
x29(t4) =0x00000040136a8066
x30(t5) =0x00000040136aa85a
x31(t6) =0x0000004076140ab8
```

Reproduced by:

```
test/jdk/jdk/internal/vm/Continuation/LiveFramesDriver.java
test/jdk/jdk/internal/vm/Continuation/Fuzz.java
```