### PR TITLE
RISC-V: loom: RVC: Fix two potential alignment issues when RVC's enabled

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1098,7 +1098,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
     __ bnez(c_rarg2, call_thaw);
 
     // Make sure the call is patchable
-    __ align(BytesPerWord);
+    __ align(4);
 
     address mark = __ pc();
     __ trampoline_call(resolve);
@@ -1126,7 +1126,7 @@ static void gen_continuation_enter(MacroAssembler* masm,
   __ bnez(c_rarg2, call_thaw);
 
   // Make sure the call is patchable
-  __ align(BytesPerWord);
+  __ align(4);
 
   address mark = __ pc();
   __ trampoline_call(resolve);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1097,6 +1097,9 @@ static void gen_continuation_enter(MacroAssembler* masm,
 
     __ bnez(c_rarg2, call_thaw);
 
+    // Make sure the call is patchable
+    __ align(BytesPerWord);
+
     address mark = __ pc();
     __ trampoline_call(resolve);
 
@@ -1121,6 +1124,9 @@ static void gen_continuation_enter(MacroAssembler* masm,
   fill_continuation_entry(masm);
 
   __ bnez(c_rarg2, call_thaw);
+
+  // Make sure the call is patchable
+  __ align(BytesPerWord);
 
   address mark = __ pc();
   __ trampoline_call(resolve);


### PR DESCRIPTION
According to x86's implementations: need to align the patchable calls to 4-byte when RVC's enabled.