### PR TITLE
RISC-V: loom: RVC: assert the position of post call nop is aligned

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -429,6 +429,7 @@ void NativeMembar::set_kind(uint32_t order_kind) {
 }
 
 void NativePostCallNop::make_deopt() {
+  assert((((intptr_t)addr_at(0)) & 3) == 0, "bad alignment");
   NativeDeoptInstruction::insert(addr_at(0));
 }
 


### PR DESCRIPTION
Assert the post call nop is 4-byte aligned when RVC is enabled, for some of the post call nops could be patched by deoptimizations, happening outside safepoints.